### PR TITLE
feat: redesign hero code block to match IDE style window

### DIFF
--- a/site/src/jsMain/kotlin/vn/id/tozydev/lucidabyss/components/sections/home/HomeHero.kt
+++ b/site/src/jsMain/kotlin/vn/id/tozydev/lucidabyss/components/sections/home/HomeHero.kt
@@ -5,6 +5,8 @@ import com.varabyte.kobweb.compose.ui.Modifier
 import com.varabyte.kobweb.compose.ui.toAttrs
 import com.varabyte.kobweb.navigation.Anchor
 import org.jetbrains.compose.web.dom.*
+import vn.id.tozydev.lucidabyss.components.widgets.CheckIcon
+import vn.id.tozydev.lucidabyss.components.widgets.PersonIcon
 import vn.id.tozydev.lucidabyss.components.widgets.code.CodeBlock
 import vn.id.tozydev.lucidabyss.strings.Strings
 import vn.id.tozydev.lucidabyss.strings.title
@@ -24,30 +26,63 @@ fun HomeHero(modifier: Modifier = Modifier) {
 
 @Composable
 private fun ShortIntro(modifier: Modifier = Modifier) {
-    CodeBlock(
-        // language=kotlin
-        code =
-            """
-            val tozydev = developer {
-                about {
-                    name = "Thanh Tân"
-                    username = "tozydev"
-                    role = Kotlin_Developer
-                }
-                technicalSkills {
-                    languages = setOf("Kotlin", "Java", "TypeScript")
-                    frameworks = setOf("Ktor", "Spring Boot", "Kobweb")
-                }
-                tools {
-                    ide = setOf("IntelliJ IDEA")
-                    codeEditor = setOf("VS Code")
-                    ai = setOf("Gemini", "GitHub Copilot")
+    Div(
+        Modifier.tw("flex flex-col rounded-xl overflow-hidden shadow-soft bg-surface border border-outline/30").then(modifier).toAttrs(),
+    ) {
+        Div(
+            Modifier.tw("flex items-center justify-between bg-surface-container-low border-b border-outline/30").toAttrs(),
+        ) {
+            Div(Modifier.tw("flex").toAttrs()) {
+                Div(
+                    Modifier.tw("flex items-center gap-2 px-4 py-3 bg-surface border-r border-outline/30 relative").toAttrs(),
+                ) {
+                    PersonIcon(Modifier.tw("w-4 h-4 text-primary"))
+                    Span(Modifier.tw("text-xs font-mono text-on-surface").toAttrs()) { Text("Profile.kt") }
+                    Div(Modifier.tw("absolute bottom-0 left-0 right-0 h-[2px] bg-primary").toAttrs())
                 }
             }
-            """.trimIndent(),
-        lang = "kotlin",
-        modifier = Modifier.tw("my-0! hero-code-block").then(modifier),
-    )
+            Div(Modifier.tw("flex gap-2 pr-4").toAttrs()) {
+                Div(Modifier.tw("w-2.5 h-2.5 rounded-full bg-outline-variant").toAttrs())
+                Div(Modifier.tw("w-2.5 h-2.5 rounded-full bg-outline-variant").toAttrs())
+                Div(Modifier.tw("w-2.5 h-2.5 rounded-full bg-outline-variant").toAttrs())
+            }
+        }
+        Div(Modifier.tw("flex-1 overflow-hidden relative").toAttrs()) {
+            CodeBlock(
+                // language=kotlin
+                code =
+                    """
+                    val tozydev = developer {
+                        about {
+                            name = "Thanh Tân"
+                            username = "tozydev"
+                            role = Kotlin_Developer
+                        }
+                        technicalSkills {
+                            languages = setOf("Kotlin", "Java", "TypeScript")
+                            frameworks = setOf("Ktor", "Spring Boot", "Kobweb")
+                        }
+                        tools {
+                            ide = setOf("IntelliJ IDEA")
+                            codeEditor = setOf("VS Code")
+                            ai = setOf("Gemini", "GitHub Copilot")
+                        }
+                    }
+                    """.trimIndent(),
+                lang = "kotlin",
+                modifier = Modifier.tw("my-0! hero-code-block !rounded-none !border-none !shadow-none"),
+            )
+        }
+        Div(
+            Modifier.tw("px-4 py-1.5 bg-primary text-on-primary text-[10px] font-mono flex justify-between items-center").toAttrs(),
+        ) {
+            Div(Modifier.tw("flex items-center gap-2").toAttrs()) {
+                CheckIcon(Modifier.tw("w-3.5 h-3.5"))
+                Span { Text("SYSTEM: OPTIMIZED") }
+            }
+            Span { Text("main* ᛡ utf-8") }
+        }
+    }
 }
 
 @Composable

--- a/site/src/jsMain/resources/styles.css
+++ b/site/src/jsMain/resources/styles.css
@@ -278,6 +278,22 @@
             background-color: var(--shiki-light-bg) !important;
             color: var(--shiki-light) !important;
         }
+
+        & .shiki {
+            counter-reset: line;
+        }
+
+        & .shiki code .line::before {
+            counter-increment: line;
+            content: counter(line);
+            display: inline-block;
+            width: 1.5rem;
+            margin-right: 1.5rem;
+            text-align: right;
+            color: var(--color-outline);
+            border-right: 1px solid var(--color-outline-variant);
+            padding-right: 0.5rem;
+        }
     }
 }
 


### PR DESCRIPTION
This commit addresses the issue to redesign the hero section code block to look like a full-featured IDE window.

- Redesigned the component `ShortIntro` inside `HomeHero.kt` to encompass a fully styled IDE window structure using `flex` elements, including macOS-style window controls, a "Profile.kt" file tab, and an optimized system status bar.
- Supported automatic light and dark mode integration by mapping the colors to generic `.bg-surface` `.bg-surface-container` UI tokens.
- Leveraged CSS counter properties in `styles.css` targeted exactly at `.hero-code-block .shiki code .line` to dynamically render syntax line numbers without meddling with Shiki's internal node configurations.
- Did not change the inner variable definition inside `val tozydev = developer { ... }`, preserving original content while transforming presentation style.

---
*PR created automatically by Jules for task [12626047077800885364](https://jules.google.com/task/12626047077800885364) started by @tozydev*