### PR TITLE
perf: optimize blog post filtering and year lookups

### DIFF
--- a/site/src/jsMain/kotlin/vn/id/tozydev/lucidabyss/pages/blog/Index.kt
+++ b/site/src/jsMain/kotlin/vn/id/tozydev/lucidabyss/pages/blog/Index.kt
@@ -17,6 +17,8 @@ import vn.id.tozydev.lucidabyss.utils.BLOG_YEAR_PARAM
 import vn.id.tozydev.lucidabyss.utils.SiteRoutes
 import vn.id.tozydev.lucidabyss.utils.allPostTopics
 import vn.id.tozydev.lucidabyss.utils.allPostYears
+import vn.id.tozydev.lucidabyss.utils.allYears
+import vn.id.tozydev.lucidabyss.utils.postsForTopic
 import vn.id.tozydev.lucidabyss.utils.postsForYear
 import vn.id.tozydev.lucidabyss.utils.resolveBlogYear
 
@@ -41,9 +43,7 @@ fun BlogPage(ctx: PageContext) {
             if (selectedTopic == null) {
                 allPostYears
             } else {
-                allPostYears.filter { year ->
-                    postsForYear(year).any { post -> post.topic == selectedTopic }
-                }
+                postsForTopic(selectedTopic).allYears()
             }
         }
     val currentYear = remember(requestedYear, years) { resolveBlogYear(requestedYear, years) }

--- a/site/src/jsMain/kotlin/vn/id/tozydev/lucidabyss/utils/Posts.kt
+++ b/site/src/jsMain/kotlin/vn/id/tozydev/lucidabyss/utils/Posts.kt
@@ -8,14 +8,18 @@ val Post.coverImagePathOrDefault: String
     get() = BasePath.prependTo(coverImage ?: "/images/default-cover.webp")
 
 fun List<Post>.allTopics(): List<String> =
-    map { it.topic }
-        .distinct()
+    asSequence()
+        .map { it.topic }
         .filter { it.isNotBlank() }
+        .distinct()
+        .toList()
 
 fun List<Post>.allYears(): List<Int> =
-    map { it.publishedAt.year }
+    asSequence()
+        .map { it.publishedAt.year }
         .distinct()
         .sortedDescending()
+        .toList()
 
 val allPostTopics: List<String> by lazy {
     Posts.allTopics()
@@ -27,8 +31,10 @@ val allPostYears: List<Int> by lazy {
 
 private val postsByTag: Map<String, List<Post>> by lazy {
     Posts
+        .asSequence()
         .flatMap { post ->
             post.tags
+                .asSequence()
                 .filter { it.isNotBlank() }
                 .map { tag -> tag to post }
         }.groupBy(
@@ -41,8 +47,17 @@ private val postsByTag: Map<String, List<Post>> by lazy {
 
 private val postsByTopic: Map<String, List<Post>> by lazy {
     Posts
+        .asSequence()
         .filter { it.topic.isNotBlank() }
         .groupBy { it.topic }
+        .mapValues { (_, posts) ->
+            posts.sortedByDescending { it.publishedAt }
+        }
+}
+
+private val postsByYear: Map<Int, List<Post>> by lazy {
+    Posts
+        .groupBy { it.publishedAt.year }
         .mapValues { (_, posts) ->
             posts.sortedByDescending { it.publishedAt }
         }
@@ -62,7 +77,7 @@ fun postsForTopic(topic: String): List<Post> =
         postsByTopic[topic].orEmpty()
     }
 
-fun postsForYear(year: Int): List<Post> = Posts.filter { it.publishedAt.year == year }
+fun postsForYear(year: Int): List<Post> = postsByYear[year].orEmpty()
 
 fun resolveBlogYear(
     year: Int?,


### PR DESCRIPTION
💡 **What:**
- Introduced a precomputed `postsByYear` lazy map in `Posts.kt` to allow $O(1)$ lookups of posts for a specific year.
- Optimized the blog index page to use `postsForTopic(selectedTopic).allYears()` instead of a nested loop over all years and posts when filtering by topic.
- Leveraged Kotlin Sequences (`asSequence()`) and optimized operator order in utility functions to reduce memory allocations and improve iteration performance.

🎯 **Why:**
The previous implementation performed multiple full passes over the entire post list when calculating available years for a selected topic, resulting in $O(\text{years} \times \text{posts})$ complexity. Additionally, fetching posts for a specific year was $O(N)$, which is now $O(1)$.

📊 **Measured Improvement:**
While a live benchmark was impractical due to the small initial data size and sandbox environment constraints, the theoretical complexity of year filtering on the blog page is reduced from $O(Y \times N)$ to $O(N_{topic} \log N_{topic})$. Furthermore, `postsForYear` lookups are now $O(1)$ instead of $O(N)$. The use of sequences also minimizes intermediate collection creation during post-processing.

---
*PR created automatically by Jules for task [10239922462037676461](https://jules.google.com/task/10239922462037676461) started by @tozydev*